### PR TITLE
Add support for TP-Link TL-WR902AC v1

### DIFF
--- a/README
+++ b/README
@@ -34,20 +34,21 @@ work with current OpenWrt / LEDE development snapshots.
 
 ## Supported Devices
 
-| Device                  | Switch Name | Switch Positions              | Verified           | Notes |
-| ----------------------- | :---------: | :---------------------------: | :----------------: | ----- |
-| Buffalo WZR-HP-AG300H   | router      | on / off / auto               |                    |       |
-| Buffalo WZR-HP-G300NH   | router      | on / off / auto               |                    |       |
-| GLI (GL.iNet) GL-AR150  | switch      | left / center / right         |                    |       |
-| GLI (GL.iNet) GL-AR300M | switch      | left / center / right         |                    |       |
-| GLI (GL.iNet) GL-MT300A | switch      | left / center / right         |                    |       |
-| GLI (GL.iNet) GL-MT300M | switch      | left / center / right         |                    |       |
-| TP-Link TL-MR12U        | mode        | 3g / router / ap              |                    |       |
-| TP-Link TL-MR13U        | mode        | 3g / router / ap              |                    |       |
-| TP-Link TL-MR3020       | mode        | 3g / wisp / ap                | :heavy_check_mark: |       |
-| TP-Link TL-MR3040       | mode        | 3g / wisp / ap                | :heavy_check_mark: | v2.0 and later |
-| TP-Link TL-WR720N       | mode        | ap / 3g / router              |                    | v3 and v4 (Chinese version) |
-| TP-Link TL-WR810N       | mode        | router-ap / repeater / client | :heavy_check_mark: | v1.1 (EU) |
+| Device                  | Switch Name | Switch Positions               | Verified           | Notes |
+| ----------------------- | :---------: | :----------------------------: | :----------------: | ----- |
+| Buffalo WZR-HP-AG300H   | router      | on / off / auto                |                    |       |
+| Buffalo WZR-HP-G300NH   | router      | on / off / auto                |                    |       |
+| GLI (GL.iNet) GL-AR150  | switch      | left / center / right          |                    |       |
+| GLI (GL.iNet) GL-AR300M | switch      | left / center / right          |                    |       |
+| GLI (GL.iNet) GL-MT300A | switch      | left / center / right          |                    |       |
+| GLI (GL.iNet) GL-MT300M | switch      | left / center / right          |                    |       |
+| TP-Link TL-MR12U        | mode        | 3g / router / ap               |                    |       |
+| TP-Link TL-MR13U        | mode        | 3g / router / ap               |                    |       |
+| TP-Link TL-MR3020       | mode        | 3g / wisp / ap                 | :heavy_check_mark: |       |
+| TP-Link TL-MR3040       | mode        | 3g / wisp / ap                 | :heavy_check_mark: | v2.0 and later |
+| TP-Link TL-WR720N       | mode        | ap / 3g / router               |                    | v3 and v4 (Chinese version) |
+| TP-Link TL-WR810N       | mode        | router-ap / repeater / client  | :heavy_check_mark: | v1.1 (EU) |
+| TP-Link TL-WR902AC      | mode        | share-eth / share-hotspot / ap | :heavy_check_mark: | v1 (EU) |
 
 Data for these devices was initially collected from the OpenWrt wiki and
 from OpenWrt / LEDE source code. Devices where the switch data has been

--- a/src/usr/lib.ar71xx/ar71xx.json-cut
+++ b/src/usr/lib.ar71xx/ar71xx.json-cut
@@ -97,6 +97,17 @@
 			}
 		}
 	},
+	"tl-wr902ac-v1": {
+		"mode": {
+			"gpios": [ 17, 14 ],
+			"codes": [ "BTN_0", "BTN_1" ],
+			"positions": {
+				"hi_lo": "share-eth",
+				"lo_hi": "share-hotspot",
+				"hi_hi": "ap"
+			}
+		}
+	},
 	"wzr-hp-ag300h": {
 		"router": {
 			"gpios": [ 6, 7 ],

--- a/src/usr/lib.ar71xx/platform.sh-cut
+++ b/src/usr/lib.ar71xx/platform.sh-cut
@@ -27,7 +27,7 @@
 # slide-switch is free software, licensed under the GNU General Public License v2.
 #
 
-. /lib/ar71xx.sh
+. /lib/functions.sh
 
 switch_data_file=$lib_dir/ar71xx.json
-board_name=$(ar71xx_board_name)
+board_name=$(board_name)

--- a/src/usr/lib.ramips/platform.sh-cut
+++ b/src/usr/lib.ramips/platform.sh-cut
@@ -27,7 +27,7 @@
 # slide-switch is free software, licensed under the GNU General Public License v2.
 #
 
-. /lib/ramips.sh
+. /lib/functions.sh
 
 switch_data_file=$lib_dir/ramips.json
-board_name=$(ramips_board_name)
+board_name=$(board_name)


### PR DESCRIPTION
Replace dropped target board_name functions with the common board_name function
(https://git.lede-project.org/?p=source.git;a=commit;h=e0b9ec8e969e1c37c284cfa2f252e9b0a71157db)