### PR TITLE
support for TP-Link TL-MR3020 v3

### DIFF
--- a/src/usr/lib.ramips/ramips.json-cut
+++ b/src/usr/lib.ramips/ramips.json-cut
@@ -72,5 +72,16 @@
 				"hi_hi": "ap"
 			}
 		}
+	},
+	"tplink,tl-mr3020-v3": {
+		"mode": {
+			"gpios": [ 41, 42 ],
+			"codes": [ "BTN_0", "BTN_1" ],
+			"positions": {
+				"lo_hi": "3G4G",
+				"hi_lo": "wisp",
+				"hi_hi": "ap"
+			}
+		}
 	}
 }


### PR DESCRIPTION
```
/sys/kernel/debug/gpio

gpiochip1: GPIOs 32-63, parent: platform/10000600.gpio, 10000600.gpio:
 gpio-37  (                    |tl-mr3020-v3:green:p) out lo    
 gpio-38  (                    |wps                 ) in  hi    
 gpio-41  (                    |sw1                 ) in  lo    
 gpio-42  (                    |sw2                 ) in  hi    
 gpio-43  (                    |tl-mr3020-v3:green:3) out hi    
 gpio-44  (                    |tl-mr3020-v3:green:w) out hi 
```