### PR TITLE
Add gl-inet AR750S support on 21.02.1

### DIFF
--- a/src/usr/share/slide-switch/switch-data.json-cut
+++ b/src/usr/share/slide-switch/switch-data.json-cut
@@ -101,6 +101,16 @@
 			}
 		}
 	},
+	"glinet,gl-ar750s-nor-nand": {
+		"switch": {
+			"gpios": [ 8 ],
+			"codes": [ "BTN_0" ],
+			"positions": {
+				"lo": "left",
+				"hi": "right"
+			}
+		}
+	},
 	"glinet,gl-mt300a": {
 		"switch": {
 			"gpios": [ 1, 2 ],


### PR DESCRIPTION
Seems like it identifies by a different name on a newer OpenWRT release.

I saw this in `logread`, when tried to use the package out of the box:

```
Fri Dec  3 23:08:13 2021 user.warn slide-switch[24186]: "glinet,gl-ar750s-nor-nand" not found in /usr/share/slide-switch/switch-data.json
Fri Dec  3 23:08:14 2021 user.warn slide-switch[24197]: "glinet,gl-ar750s-nor-nand" not found in /usr/share/slide-switch/switch-data.json
```

So, I applied the same changes in this PR.

In order to test, I modified the script to:
```
# cat /etc/rc.button/switch-left
#!/bin/sh
echo $BUTTON, $ACTION > /tmp/output
```

and confirmed it's working:
```
# cat /tmp/output
switch-left, release
```

Also, I report that the package is working on AR750S, thank you for the great work! Lmk if I should update devices table in README.

----
OpenWRT release I'm on:
```
# cat /etc/openwrt_release
DISTRIB_ID='OpenWrt'
DISTRIB_RELEASE='21.02.1'
DISTRIB_REVISION='r16325-88151b8303'
DISTRIB_TARGET='ath79/nand'
DISTRIB_ARCH='mips_24kc'
DISTRIB_DESCRIPTION='OpenWrt 21.02.1 r16325-88151b8303'
DISTRIB_TAINTS=''
```