### PR TITLE
Verify GL-AR300M16

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ position of each switch. To disable or re-enable this behaviour, run
 | [GL.iNet GL-AR150][]           | mode         | left / center / right          |                    |       |
 | [GL.iNet GL-AR300M][]          | mode         | left / center / right          | :heavy_check_mark: |       |
 | [GL.iNet GL-AR300M-Lite][]     | mode         | left / center / right          |                    |       |
-| [GL.iNet GL-AR300M16][]        | mode         | left / center / right          |                    |       |
+| [GL.iNet GL-AR300M16][]        | mode         | left / center / right          | :heavy_check_mark: |       |
 | [GL.iNet GL-AR750][]           | mode         | dot / clear                    | :heavy_check_mark: |       |
 | [GL.iNet GL-AR750S][]          | mode         | dot / clear                    | :heavy_check_mark: |       |
 | [GL.iNet GL-E750][]            | mode         | dot / clear                    | :heavy_check_mark: |       |


### PR DESCRIPTION
Confirmed working on this device. Right switch position is blocked by case.

```
Mon Aug 22 13:18:07 2022 user.notice slide-switch[29472]: trigger_button_event: triggering button event with BUTTON="mode-center" ACTION="released" SEEN="50"
Mon Aug 22 13:18:07 2022 user.notice root: the button was mode-center and the action was released
Mon Aug 22 13:18:07 2022 user.notice slide-switch[29472]: trigger_button_event: triggering button event with BUTTON="mode-left" ACTION="pressed" SEEN="50"
Mon Aug 22 13:18:07 2022 user.notice root: the button was mode-left and the action was pressed
Mon Aug 22 13:18:12 2022 user.notice slide-switch[29520]: trigger_button_event: triggering button event with BUTTON="mode-left" ACTION="released" SEEN="5"
Mon Aug 22 13:18:12 2022 user.notice root: the button was mode-left and the action was released
Mon Aug 22 13:18:12 2022 user.notice slide-switch[29520]: trigger_button_event: triggering button event with BUTTON="mode-center" ACTION="pressed" SEEN="5"
Mon Aug 22 13:18:12 2022 user.notice root: the button was mode-center and the action was pressed
```

mode-center:
```gpiochip0: GPIOs 0-31, parent: platform/18040000.gpio, 18040000.gpio:
 gpio-0   (                    |button right        ) in  lo IRQ 
 gpio-1   (                    |button left         ) in  lo IRQ 
 gpio-3   (                    |reset               ) in  hi IRQ ACTIVE LOW
 gpio-12  (                    |green:status        ) out lo ACTIVE LOW
 gpio-13  (                    |green:lan           ) out lo ACTIVE LOW
 gpio-14  (                    |red:wlan            ) out lo ACTIVE LOW
 gpio-16  (                    |scl                 ) out hi 
 gpio-17  (                    |sda                 ) out hi 
 ```