### PR TITLE
Added and verified GL.iNet GL-MT3000 Beryl AX

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ position of each switch. To disable or re-enable this behaviour, run
 | [GL.iNet GL-AR750S][]          | mode         | dot / clear                    | :heavy_check_mark: |       |
 | [GL.iNet GL-E750][]            | mode         | dot / clear                    | :heavy_check_mark: |       |
 | [GL.iNet GL-MT1300][]          | mode         | dot / clear                    | :heavy_check_mark: |       |
+| [GL.iNet GL-MT3000][]          | mode         | dot / clear                    | :heavy_check_mark: |       |
 | [GL.iNet GL-MT300A][]          | mode         | left / center / right          | :heavy_check_mark: |       |
 | [GL.iNet GL-MT300N v1][]       | mode         | left / center / right          |                    |       |
 | [GL.iNet GL-MT300N v2][]       | mode         | left / center / right          | :heavy_check_mark: |       |
@@ -76,6 +77,7 @@ where the switch data has been tested and verified correct by users.
 [GL.iNet GL-AR750S]: https://openwrt.org/toh/gl.inet/gl-ar750s
 [GL.iNet GL-E750]: https://openwrt.org/toh/gl.inet/gl-e750
 [GL.iNet GL-MT1300]: https://openwrt.org/toh/gl.inet/gl-mt1300_v1
+[GL.iNet GL-MT3000]: https://openwrt.org/toh/gl.inet/gl-mt3000
 [GL.iNet GL-MT300A]: https://openwrt.org/toh/gl.inet/gl-mt300a
 [GL.iNet GL-MT300N v1]: https://openwrt.org/toh/gl.inet/gl-mt300n_v1
 [GL.iNet GL-MT300N v2]: https://openwrt.org/toh/gl.inet/gl-mt300n_v2

--- a/src/usr/share/slide-switch/functions.sh-cut
+++ b/src/usr/share/slide-switch/functions.sh-cut
@@ -36,7 +36,7 @@ initd_dir=@sysconfdir@/init.d
 
 board_name=/tmp/sysinfo/board_name
 gpio_table=/sys/kernel/debug/gpio
-device_tree_keys=/proc/device-tree/keys
+device_tree_keys=/proc/device-tree/gpio-keys
 hotplug_call=/sbin/hotplug-call
 rc_button=/etc/rc.button
 

--- a/src/usr/share/slide-switch/switch-data.json-cut
+++ b/src/usr/share/slide-switch/switch-data.json-cut
@@ -107,6 +107,15 @@
 			}
 		}
 	},
+	"glinet,gl-mt3000": {
+		"mode": {
+			"keys": [ "mode" ],
+			"positions": {
+				"lo": "dot",
+				"hi": "clear"
+			}
+		}
+	},
 	"glinet,gl-mt300a": {
 		"mode": {
 			"keys": [ "0x100", "0x101" ],


### PR DESCRIPTION
Just like mayanez in #25 I managed to get it working on my GL-MT3000. However I didn't just add an alias to `gl-ar750` in `switch-data.json-cut` because apparently for the GL-MT3000 the `hi` and `lo` positions are swapped.

![Bildschirmfoto 2024-04-22 um 22 59 15](https://github.com/jefferyto/openwrt-slide-switch/assets/42060641/cdee8309-02c0-4515-8fee-c0fb4a8178b3)

I also had to modify the `device_tree_keys` path in: [openwrt-slide-switch/src/usr/share/slide-switch/functions.sh-cut](https://github.com/jefferyto/openwrt-slide-switch/blob/e0a71644acbf50e95c9a43b639871b14d5cc05f8/src/usr/share/slide-switch/functions.sh-cut#L39)
I assume this change is necessary anyway to be compatible with the newest version of openwrt. However if it breaks compatibility with something, there needs to be a solution for how to handle it first. Maybe just testing for both paths in `functions.sh-cut`.
